### PR TITLE
Update socket path to match previous instruction

### DIFF
--- a/node-setup/address.md
+++ b/node-setup/address.md
@@ -48,7 +48,7 @@ which will enable us to receive and send ada.
    you first need to set environment variable `CARDANO_NODE_SOCKET_PATH`
    to the socket-path specified in your node configuration:
 
-        export CARDANO_NODE_SOCKET_PATH=db/node-socket
+        export CARDANO_NODE_SOCKET_PATH=db/node.socket
 
    and make sure that your node is running.  Then use
 


### PR DESCRIPTION
The socket path specified in step 3 does not match with the path specified in other documentation. This is leading to some becoming confused and using the wrong path.