### PR TITLE
Update socket path in Transactions Tutorial

### DIFF
--- a/node-setup/tx.md
+++ b/node-setup/tx.md
@@ -10,13 +10,13 @@ is in file `addr1.skey`.
 
 1. We first want to calculate the necessary fees for this transaction.
    In order to do this, we need the _protocol parameters_, which we can save to file `protocol.json`
-   with
+   with:
 
         cardano-cli shelley query protocol-parameters \
             --testnet-magic 42 > protocol.json
 
    Out simple transaction will have one input (from `addr1`) and two outputs,
-   100 ada to `addr2` and the change back to `addr1`. We can calculate the fees with
+   100 ada to `addr2` and the change back to `addr1`. We can calculate the fees with:
 
         cardano-cli shelley transaction calculate-min-fee \
             --tx-in-count 1 \
@@ -34,7 +34,7 @@ is in file `addr1.skey`.
    So we need to pay 168141 lovelace fee.
 
    Assuming we want to spend an original utxo containing 1,000,000 ada (1,000,000,000,000 lovelace),
-   we therefore will have 
+   we therefore will have: 
 
         expr 1000000000000 - 100000000 - 168141
 
@@ -75,9 +75,9 @@ is in file `addr1.skey`.
 
    This writes the signed transaction to file `tx001.signed`.
 
-5. Now we can submit the transaction with
+5. Now we can submit the transaction with:
 
-        export CARDANO_NODE_SOCKET_PATH=db/node-socket
+        export CARDANO_NODE_SOCKET_PATH=db/node.socket
         cardano-cli shelley transaction submit \
             --tx-filepath tx001.signed \
             --testnet-magic 42


### PR DESCRIPTION
I checked all tutorials and this should be (hopefully) the last update of socket path so we should have (after this is merged) `node.socket` everywhere and stick to this naming.