### PR TITLE
Added an example of transferring value

### DIFF
--- a/pioneers-testnet/pioneers-exercise-2.md
+++ b/pioneers-testnet/pioneers-exercise-2.md
@@ -91,7 +91,21 @@ In this excercise we will be following steps from [Creating a Simple Transaction
    | ttl       | 500000  |
    | fee       | 1000000 |
 
-   The settings that are used here indicate that the transaction should be processed before slot 500,000 and  that it will cost no more than 1 Ada to submit (a safe value for a simple transaction on the Testnet).  You must pay this (small) fee every time you successfully process a transaction on the Cardano Blockchain.  It will be distributed as part of the pool rewards.  The source of this fee is encoded in the transaction as a UTxO.  We are now ready to sign the transaction and submit it to the chain.
+   The settings that are used here indicate that the transaction should be processed before slot 500,000 and  that it will cost no more than 1 Ada to submit (a safe value for a simple transaction on the Testnet).  You must pay this (small) fee every time you successfully process a transaction on the Cardano Blockchain.  It will be distributed as part of the pool rewards.  The source of this fee is encoded in the transaction as a UTxO.  
+
+Here's an **example** of a transaction that instructs the transfer of 100,000,000 lovelace from one account (account A) to another account (account B).
+
+	cardano-cli shelley transaction build-raw \
+		--tx-in a72ec98117def0939cc310b17de10d218f41ef5c84d94a89fe6097318d3de983#0 \
+		--tx-out 82065820acc8de978a8c484a6797a014c28f6746c98ebe93d7f4498d66ea639ec953933f+100000000 \
+		--tx-out a72ec98117def0939cc310b17de10d218f41ef5c84d94a89fe6097318d3de983+99899000000 \
+		--fee 1000000 \
+		--ttl 500000 \
+		--tx-body-file txbody
+		
+Note that account A's address ```(a72ec98117def0939cc310b17de10d218f41ef5c84d94a89fe6097318d3de983)``` appears twice. Once in the transaction input and again as an output. This is the change being returned to account A, where the change is equal to the input from account A, minus the value being transferred to account B, minus the fee.
+
+We are now ready to sign the transaction and submit it to the chain.
 
 4. Sign your transaction in txbody using the signing key for *myaddr* (created in Excercise 1) :
 


### PR DESCRIPTION
It's not entirely clear from the tutorial, or the cardano-cli help, that multiple tx-out parameters can be specified. Including a worked example helps clarify this.