### PR TITLE
missing backslash  in staking-key.md

### DIFF
--- a/node-setup/staking-key.md
+++ b/node-setup/staking-key.md
@@ -90,7 +90,7 @@ Let us remedy this now and create staking keys and a staking address!
    We sign it:
 
         cardano-cli shelley transaction sign \
-            --tx-body-file tx.raw
+            --tx-body-file tx.raw \
             --signing-key-file payment.skey \
             --signing-key-file staking.skey \
             --testnet-magic 42 \


### PR DESCRIPTION
was missing backslash at the transaction signing stage