### PR TITLE
CLI updates to latest tag (pioneer-3)

### DIFF
--- a/node-setup/GuideForExcercise1.md
+++ b/node-setup/GuideForExcercise1.md
@@ -90,10 +90,10 @@ We change our working directory to the downloaded source code folder:
     cd cardano-node
 
 For reproducible builds, we should check out a specific release, a specific "tag". 
-For the FF-testnet, we will use tag `pioneer`, which we can check out as follows:
+For the FF-testnet, we will use tag `pioneer-#`, which we can check out as follows:
 
     git fetch --all --tags
-    git checkout tags/pioneer
+    git checkout tags/pioneer-#
 
 
 ## Build and install the node
@@ -294,10 +294,10 @@ The files are in plain-text format and human readable:
 
 Now we can use the verification key we just created to make an address. For now, we will use an address type that can receive and send transactions, but cannot do staking: `enterprise` type. 
 
-    cardano-cli shelley address build-enterprise \
+    cardano-cli shelley address build \
         --payment-verification-key-file payment.vkey
 
-        > 820658...
+        > 61...
 
 Let's store this address in a file:
 
@@ -314,7 +314,7 @@ To query your address (see the utxo's at that address),you first need to set env
 Then use
    
     cardano-cli shelley query filtered-utxo \
-        --address 8206582..... \
+        --address 61... \
         --testnet-magic 42
   
  The output should look like this, note that we do not have any funds yet. 

--- a/node-setup/address.md
+++ b/node-setup/address.md
@@ -33,10 +33,6 @@ which will enable us to receive and send ada.
 
         > 61...
 
-   The "enterprise" address type can just receive payments and does not participate in staking.
-   This is fine for the purpose of this tutorial, we will cover staking in other tutorials.
-   Note that in recent versions of the command, you should just use `build` rather than `build-enterprise`.
-
    It is probably a good idea to store this address in a file:
 
         cardano-cli shelley address build \

--- a/node-setup/address.md
+++ b/node-setup/address.md
@@ -28,17 +28,17 @@ which will enable us to receive and send ada.
 
 2. Now we can use the verification key we just created to make an address:
 
-        cardano-cli shelley address build-enterprise \
+        cardano-cli shelley address build \
             --payment-verification-key-file addr.vkey
 
-        > 820658...
+        > 61...
 
    The "enterprise" address type can just receive payments and does not participate in staking.
    This is fine for the purpose of this tutorial, we will cover staking in other tutorials.
 
    It is probably a good idea to store this address in a file:
 
-        cardano-cli shelley address build-enterprise \
+        cardano-cli shelley address build \
             --payment-verification-key-file addr.vkey > addr
 
    Instead of writing the generated address to the console, 
@@ -53,7 +53,7 @@ which will enable us to receive and send ada.
    and make sure that your node is running.  Then use
 
         cardano-cli shelley query filtered-utxo \
-            --address 820658... \
+            --address 61... \
             --testnet-magic 42
 
    (The `--testnet-magic 42` is specific to the FF-testnet, for mainnet we would use `--mainnet` instead.)

--- a/node-setup/build.md
+++ b/node-setup/build.md
@@ -75,10 +75,10 @@
         cd cardano-node
 
 4. For reproducible builds, we should check out a specific release, a specific "tag". 
-   For the FF-testnet, we will use tag `pioneer`, which we can check out as follows:
+   For the FF-testnet, we will use tag `pioneer-#`, which we can check out as follows:
 
         git fetch --all --tags
-        git checkout tags/pioneer
+        git checkout tags/pioneer-#
 
 5. Now we build and install the node with ``cabal``, 
    which will take a couple of minutes the first time you do a build. Later builds will be much faster, because everything that does not change will be cached.

--- a/node-setup/tx.md
+++ b/node-setup/tx.md
@@ -79,7 +79,7 @@ is in file `addr1.skey`.
 
         export CARDANO_NODE_SOCKET_PATH=db/node.socket
         cardano-cli shelley transaction submit \
-            --tx-filepath tx001.signed \
+            --tx-file tx001.signed \
             --testnet-magic 42
 
 6. We must give it some time to get incorporated into the blockchain, but eventually, we will see the effect:

--- a/pioneers-testnet/pioneers-exercise-2.md
+++ b/pioneers-testnet/pioneers-exercise-2.md
@@ -4,6 +4,8 @@
 
 In the first exercise, we set up a Cardano node and ran it.  In this exercise, we will build transactions that are submitted to the Blockchain.  Transactions are the basic mechanism that is used to transfer Ada between stakeholders, register staking pools, stake Ada, and many other things.
 
+> This exercise has been created with the pioneer-3 build tag in mind and does not reflect any cli changes since this release.
+
 ### Prerequisites
 
 1. Complete Exercise Sheet 1, and confirm that you have successfully built and run a node.  Also make sure that you have requested some test Ada through the spreadsheet.
@@ -14,16 +16,16 @@ In the first exercise, we set up a Cardano node and ran it.  In this exercise, w
 
 3. Checkout the latest version of the Shelley node and CLI from source, and rebuild and reinstall them if they have changed:
 
-        git checkout pioneer-2
+        git checkout pioneer-3
         cabal build all
         …
 
     Before building, you might want to confirm that you are on the correct tagged version:
 
         git branch
-	>* (HEAD detached at pioneer-2)
+	>* (HEAD detached at pioneer-3)
 	
-	>  master
+	>*  master
 	  
 ### Objectives
 
@@ -41,6 +43,8 @@ If you have any questions or encounter any problems, please feel free to use the
 ### Exercises
 
 In this excercise we will be following steps from [Creating a Simple Transaction tutorial](https://github.com/input-output-hk/cardano-tutorials/blob/master/node-setup/tx.md)
+
+You will need to give the correct Testnet Magic Id for the Testnet, as supplied by IOHK in the Genesis file (e.g. 42).
 
 1. If you are not on the correct version of the node, then some of these commands may not work.
    It may be frustrating to stop and restart a working system, but it is better than discovering that
@@ -70,12 +74,16 @@ In this excercise we will be following steps from [Creating a Simple Transaction
    Create a new address *myaddr2*:
 
         cardano-cli shelley address key-gen …
-        cardano-cli shelley address build-enterprise …
+        cardano-cli shelley address build …
 
 3. Build a transaction to transfer Ada from *myaddr* to *myaddr2*.  You will need to use the Shelley transaction processing operations:
 
         cardano-cli shelley transaction build-raw \
-            --tx-body-file txbody …
+            --tx-body-file txbody \
+            --tx-in tx_in \
+            --tx-out tx_out \
+            --ttl \
+            --fee …
 
    This is the most basic form of transaction construction.  We will use more sophisticated ones later.  The transaction will be created in the file txbody. You will need to provide explicit transaction inputs and outputs.
 
@@ -91,7 +99,7 @@ In this excercise we will be following steps from [Creating a Simple Transaction
    | ttl       | 500000  |
    | fee       | 1000000 |
 
-   The settings that are used here indicate that the transaction should be processed before slot 500,000 and  that it will cost no more than 1 Ada to submit (a safe value for a simple transaction on the Testnet).  You must pay this (small) fee every time you successfully process a transaction on the Cardano Blockchain.  It will be distributed as part of the pool rewards.  The source of this fee is encoded in the transaction as a UTxO.  We are now ready to sign the transaction and submit it to the chain.
+   The settings that are used here indicate that the transaction should be processed before slot 500,000 and that it will cost no more than 1 Ada to submit (a safe value for a simple transaction on the Testnet).  You must pay this (small) fee every time you successfully process a transaction on the Cardano Blockchain.  It will be distributed as part of the pool rewards.  The source of this fee is encoded in the transaction as a UTxO.  We are now ready to sign the transaction and submit it to the chain.
 
 4. Sign your transaction in txbody using the signing key for *myaddr* (created in Excercise 1) :
 
@@ -99,15 +107,13 @@ In this excercise we will be following steps from [Creating a Simple Transaction
             --tx-body-file txbody \
             --signing-key-file txsign \
             --testnet-magic … \
-            --tx-body-file txbody
-
-   You will need to give the correct Network Magic Id for the Testnet, as supplied by IOHK in the Genesis file (e.g. 42).
+            --tx-file txfile
 
 5. Submit your transaction to the Blockchain:
 
         cardano-cli shelley transaction submit \
             --testnet-magic … \
-            --tx-body-file txbody
+            --tx-file txfile
 
    If you made a mistake or if the node is not running or it cannot be contacted, you will see an error.  Just correct the error or kill/restart the node in this case and try again.
 
@@ -120,14 +126,14 @@ In this excercise we will be following steps from [Creating a Simple Transaction
 7. Finally, build a transaction that sends a total of 1,000 Ada from *myaddr* to two different addresses (a multi-address transaction).
 
         cardano-cli shelley address key-gen …
-        cardano-cli shelley address build-enterprise …
+        cardano-cli shelley address build …
         cardano-cli shelley address key-gen …
-        cardano-cli shelley address build-enterprise …
+        cardano-cli shelley address build …
         cardano-cli shelley transaction build-raw …
 
    The required fee will be higher than before, since part of the cost is based on the number of addresses that the output is sent to.  You can check that the fee will be sufficient before you build the transaction using:
 
-        cardano-cli shelley query protocol-parameters --testnet-magic 42 > protocol-parameters.json
+        cardano-cli shelley query protocol-parameters --testnet-magic … > protocol-parameters.json
         cardano-cli shelley transaction calculate-min-fee --protocol-params-file protocol-parameters.json …
 
    Sign, submit and wait for the transaction to be processed as before.


### PR DESCRIPTION
Updated the cli commands in the tutorial to reflect the current pioneer build + F&F testnet.

Added a tag\pioneer-# to indicate that the numbered versions are to be used.

Exercise-2.md:
- Added tag pioneer-3 (up from 2)
- Moved the testnet-magic notification further up to centralize it for all commands.
- Added full build-raw command to better align with the sign and submit commands. (this could be reversed but then the sign and submit should also be abbreviated and users should check the instruction in the tx.md tutorial.)