### PR TITLE
Moving monitoring tutorials to the end of list.

### DIFF
--- a/node-setup/README.md
+++ b/node-setup/README.md
@@ -6,8 +6,6 @@ In these tutorials, we will cover the following topics:
 - [Building a node from source and connecting it to the Cardano mainnet](build.md).
 - [Starting the node and connecting to testnet](start-node-connect-to-testnet.md)
 - [Understanding the configuration files](understanding-config-files.md)
-- [Monitoring a node with EKG](ekg.md).
-- [Monitoring a node with Prometheus](prometheus.md).
 - [Configuring logging](logging.md).
 - [Block producers and relays](topology.md).
 - [Command line interface](cli.md).
@@ -16,4 +14,6 @@ In these tutorials, we will cover the following topics:
 - [Stake keys and stake addresses](staking-key.md).
 - [Creating an operational node certificate](node-op-cert.md).
 - [Registering a stake pool](pool.md).
+- [Monitoring a node with EKG](ekg.md).
+- [Monitoring a node with Prometheus](prometheus.md).
 - [Quick guide for excercise 1](GuideForExcercise1.md)


### PR DESCRIPTION
Discussed with Lars that it would make sense to move the monitoring tutorials to the end of the list. Once one has accomplished setting up a stake pool, that would be a more suitable time to configure the monitoring tools.