### PR TITLE
Revert "fixing typo on --stake-verification-key-file--staking"

### DIFF
--- a/node-setup/address.md
+++ b/node-setup/address.md
@@ -39,7 +39,7 @@ Let's produce our cryptographic keys first, as we will need them to later create
 
 		cardano-cli shelley address build \
 		--payment-verification-key-file payment.vkey \
-		--staking-verification-key-file stake.vkey \
+		--stake-verification-key-file stake.vkey \
 		--out-file payment.addr  
      
 This created the file payment.addr, let's check its content: 


### PR DESCRIPTION
Reverts input-output-hk/cardano-tutorials#122

`---stake-verification-key-file` is correct.