### PR TITLE
fix cardano-cli shelley address build params

### DIFF
--- a/node-setup/address.md
+++ b/node-setup/address.md
@@ -39,8 +39,8 @@ Let's produce our cryptographic keys first, as we will need them to later create
 
 		cardano-cli shelley address build \
 		--payment-verification-key-file payment.vkey \
-		--stake-verification-key-file stake.vkey \
-		--out-file payment.addr  
+		--staking-verification-key-file stake.vkey \
+		> payment.addr  
      
 This created the file payment.addr, let's check its content: 
 


### PR DESCRIPTION
my node is on 1.12.0 - and the help of the problematic command:
$ cardano-cli shelley address build
Usage: cardano-cli shelley address build --payment-verification-key-file FILE 
                                         [--staking-verification-key-file FILE]
  Build a Shelley payment addres, with optional delegation to a stake address.

Available options:
  --payment-verification-key-file FILE
                           Filepath of the payment verification key.
  --staking-verification-key-file FILE
                           Filepath of the staking verification key.