### PR TITLE
Remove formating inside MD code env

### DIFF
--- a/node-setup/KES_period.md
+++ b/node-setup/KES_period.md
@@ -21,5 +21,5 @@ With this we are able to generate a operational certificate for our stake pool:
         --hot-kes-verification-key-file kes1-002.vkey \
         --cold-signing-key-file node1.skey \
         --operational-certificate-issue-counter node1.counter \
-        __--kes-period 120 \__
+        --kes-period 120 \
         --out-file node1-002.cert


### PR DESCRIPTION
Bold text is not rendered inside of the code environment and the underscores could lead to confusion or errors when copy-pasting.