### PR TITLE
Added the missing option  --testnet-magic

### DIFF
--- a/Shelley-testnet/solutions/Exercise-1-solutions.md
+++ b/Shelley-testnet/solutions/Exercise-1-solutions.md
@@ -288,8 +288,8 @@ Now we can use the verification key we just created to make an address. For now,
 
     cardano-cli shelley address build \
         --payment-verification-key-file payment.vkey \
-	--stake-verification-key-file stake.vkey \
-	--out-file payment.addr
+	--out-file payment.addr \
+	--testnet-magic 42
 
         > 01ed8ae0843a3...
 


### PR DESCRIPTION
Removed stake-verification-key option as no stake-verification-key is generated in this tutorial. Also, --testnet-magic option is added. Without that, the command throws error.