### PR TITLE
Correcting stake pool certificate generation command

### DIFF
--- a/Shelley-testnet/solutions/Exercise-5-solutions.md
+++ b/Shelley-testnet/solutions/Exercise-5-solutions.md
@@ -78,7 +78,8 @@ LATEST NODE TAG: 1.13.0
             --pool-cost 256000000 \
             --pool-margin 0.07 \
             --reward-account-verification-key-file stake.vkey \
-            --pool-owner-staking-verification-key-file stake.vkey \
+            --pool-owner-stake-verification-key-file stake.vkey \
+	    --testnet-magic 42 \
             --out-file pool.cert
 
 2. 	Pledge some stake to your stake pool.


### PR DESCRIPTION
Correcting cardano-cli shelley stake-pool registration-certificate commands with --pool-owner-stake-verification-key-file option & adding --testnet-magic 42